### PR TITLE
Check if index is set to avoid undefined index error

### DIFF
--- a/src/NextCaller/NextCallerBaseClient.php
+++ b/src/NextCaller/NextCallerBaseClient.php
@@ -69,7 +69,7 @@ abstract class NextCallerBaseClient
         if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
             return $result;
         }
-        if (!$result || !$result['error']) {
+        if (!$result || !isset($result['error'])) {
             throw new FormatException('Not valid error response', 3, null, $request, $response);
         }
         $message = $result['error']['message'];


### PR DESCRIPTION
Using PHP strict will throw an undefined index error if the result set is empty