### PR TITLE
Update guzzle requirement to be the correct one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "MIT",
 
     "require": {
-        "guzzle/guzzle": "3.9.*"
+        "guzzlehttp/guzzle": "3.9.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Readme lists the requirement as guzzlehttp/guzzle. Composer also throws a recommendation to use guzzlehttp as guzzle is listed as abandoned.